### PR TITLE
Specifically set content-type headers for js/css

### DIFF
--- a/upload_to_s3.sh
+++ b/upload_to_s3.sh
@@ -157,5 +157,6 @@ fi
 
 s3cmd sync --acl-public --exclude "*.*" --include "*.js" --add-header='Content-Type: application/javascript' --add-header $MAXAGE_HEADER $ENCODING_HEADER "$TEMPDIR/" "$BUCKET_URL"
 s3cmd sync --acl-public --exclude "*.*" --include "*.css" --add-header='Content-Type: text/css' --add-header $MAXAGE_HEADER $ENCODING_HEADER "$TEMPDIR/" "$BUCKET_URL"
+s3cmd sync --acl-public --exclude "*.*" --include "*.html" --add-header='Content-Type: text/html' --add-header $MAXAGE_HEADER $ENCODING_HEADER "$TEMPDIR/" "$BUCKET_URL"
 s3cmd sync -M --acl-public --exclude "*.css" --exclude "*.js" --add-header $MAXAGE_HEADER $ENCODING_HEADER "$TEMPDIR/" "$BUCKET_URL"
 rm -rf $TEMPDIR

--- a/upload_to_s3.sh
+++ b/upload_to_s3.sh
@@ -155,5 +155,7 @@ else
     fi
 fi
 
-s3cmd sync -M --acl-public --add-header $MAXAGE_HEADER $ENCODING_HEADER "$TEMPDIR/" "$BUCKET_URL"
+s3cmd sync --acl-public --exclude "*.*" --include "*.js" --add-header='Content-Type: application/javascript' --add-header $MAXAGE_HEADER $ENCODING_HEADER "$TEMPDIR/" "$BUCKET_URL"
+s3cmd sync --acl-public --exclude "*.*" --include "*.css" --add-header='Content-Type: text/css' --add-header $MAXAGE_HEADER $ENCODING_HEADER "$TEMPDIR/" "$BUCKET_URL"
+s3cmd sync -M --acl-public --exclude "*.css" --exclude "*.js" --add-header $MAXAGE_HEADER $ENCODING_HEADER "$TEMPDIR/" "$BUCKET_URL"
 rm -rf $TEMPDIR

--- a/upload_to_s3.sh
+++ b/upload_to_s3.sh
@@ -155,8 +155,5 @@ else
     fi
 fi
 
-s3cmd sync --acl-public --exclude "*.*" --include "*.js" --add-header='Content-Type: application/javascript' --add-header $MAXAGE_HEADER $ENCODING_HEADER "$TEMPDIR/" "$BUCKET_URL"
-s3cmd sync --acl-public --exclude "*.*" --include "*.css" --add-header='Content-Type: text/css' --add-header $MAXAGE_HEADER $ENCODING_HEADER "$TEMPDIR/" "$BUCKET_URL"
-s3cmd sync --acl-public --exclude "*.*" --include "*.html" --add-header='Content-Type: text/html' --add-header $MAXAGE_HEADER $ENCODING_HEADER "$TEMPDIR/" "$BUCKET_URL"
-s3cmd sync -M --acl-public --exclude "*.css" --exclude "*.js" --add-header $MAXAGE_HEADER $ENCODING_HEADER "$TEMPDIR/" "$BUCKET_URL"
+s3cmd sync --acl-public --add-header $MAXAGE_HEADER $ENCODING_HEADER "$TEMPDIR/" "$BUCKET_URL"
 rm -rf $TEMPDIR


### PR DESCRIPTION
The encoding was causing problems with the content-type header. Because the content was gzipped prior to upload, the automatic mime-type detection must have determined it was type gzip, so the content-type was “application/gzip”, which is clearly wrong.